### PR TITLE
Adding ADB Guide (Source: XDADevelopers/Github Gists)

### DIFF
--- a/Guides/ADB-Sideloading.md
+++ b/Guides/ADB-Sideloading.md
@@ -1,1 +1,37 @@
+# Sideloading APKs in to Windows Subsystem for Android
+-------------
 
+## Setting up ADB to work with WSA
+- Launch **Windows Subsystem for Android**.
+- Here, enable **Developer mode** then tap on **Manage developer settings**.
+- Use your left mousebutton to scroll down until you find **Wireless debugging**. Tap to open it and enable it.
+- Tap on **Pair device with pairing code**. 
+- Take note of **Wi-Fi pairing code**, and **IP address and port**.
+- Launch Windows Terminal and make sure ADB is installed ([install ADB](https://www.xda-developers.com/install-adb-windows-macos-linux/#adbsetupwindows)).
+- Use command ``adb pair <IP:port>`` to pair ADB with WSA.
+- In Wireless debugging window, see **Device name** and under it **IP address and port**.
+- Use command ``adb connect <IP:port>`` to connect WSA with ADB.
+
+Once this is done, use command ``adb devices`` to make sure that WSA is connected.
+
+
+## Installing APKs using ADB
+Now you can install any app you want, but I personally suggest installing a web browser and a file manager first. 
+Here's the [direct download link](https://github.com/bromite/bromite/releases/latest/download/x64_ChromePublic.apk) to the latest Bromite x64 build.
+- Download the APK.
+- Open File Explorer, right click on downloaded APK and tap on Copy as path.
+- Launch Windows Terminal.
+- Use ``adb install <file path>`` to install the APK.   
+[**P.S.** You can right click to paste in Terminal]
+- Repeat this process for a file manager app. I recommend using MiX, you can use what you want.
+
+## After installation using ADB
+You can now open the web browser you installed in Android, and download and install Aurora Store like you do on any Android device - normally sideloading APK without using ADB.
+***
+&nbsp; 
+
+### A list of suggested apps to install on WSA:
+- [microG](https://microg.org/): A free-as-in-freedom re-implementation of Google’s proprietary Android user space apps and libraries.
+- [Aurora Store](https://files.auroraoss.com/AuroraStore/Stable/): an app store that lets you download apps from Google Play without a Google account.
+- [MiX](https://forum.xda-developers.com/t/app-2-2-mixplorer-v6-x-released-fully-featured-file-manager.1523691/): MiXplorer mix of explorers (SD, FTP, Lan, Cloud and other storage explorers) is a fast, smooth, beautiful, reliable and full-featured file manager with a simple and intuitive user interface.
+- [Bromite](https://github.com/bromite/bromite): A Chromium fork with support for ad blocking and enhanced privacy.

--- a/Guides/Sideloading.md
+++ b/Guides/Sideloading.md
@@ -7,8 +7,8 @@
 
 |Application|
 |-----------|
-|[<img src="https://user-images.githubusercontent.com/68516357/226143645-0a0ff0df-00f4-4d69-a257-1ffbee039f36.png" style="width: 250px;"/>](https://github.com/MustardChef/WSABuilds/blob/master/Guides/WSA-Sideloader.md)|
-|[<img src="https://user-images.githubusercontent.com/68516357/226144462-25e8ba07-9f5b-424b-9ecf-b973e8f396b2.png" style="width: 300px;" style="float: left;"/>](https://github.com/MustardChef/WSABuilds/blob/master/Guides/WSAPacman.md)|
-|[<img src="https://user-images.githubusercontent.com/68516357/226143960-70ba58b6-7339-48c8-9f25-602e7236eaf5.png" style="width: 240px;" style="float: left;"/>](https://github.com/MustardChef/WSABuilds/blob/master/Guides/ADB-Sideloading.md)|
+|[<img src="https://user-images.githubusercontent.com/68516357/226143645-0a0ff0df-00f4-4d69-a257-1ffbee039f36.png" style="width: 350px;"/>](https://github.com/MustardChef/WSABuilds/blob/master/Guides/WSA-Sideloader.md)|
+|[<img src="https://user-images.githubusercontent.com/68516357/226144462-25e8ba07-9f5b-424b-9ecf-b973e8f396b2.png" style="width: 350px;" style="float: left;"/>](https://github.com/MustardChef/WSABuilds/blob/master/Guides/WSAPacman.md)|
+|[<img src="https://user-images.githubusercontent.com/68516357/226143960-70ba58b6-7339-48c8-9f25-602e7236eaf5.png" style="width: 346px;" style="float: left;"/>](https://github.com/MustardChef/WSABuilds/blob/master/Guides/ADB-Sideloading.md)|
 
 


### PR DESCRIPTION
## Sources: 

- [XDA-Developers](https://www.xda-developers.com/how-to-sideload-android-apps-on-windows-11/)
- [GitHub Gists](https://gist.github.com/pratyakshm/b06c326fc3e54a52b6cbde1044fc35a9?permalink_comment_id=3935147)
