### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@
   <tr>
     <td>v2305.40000.3.0</td>
     <td>➖</td>
-    <td><a href="https://github.com/cinit/WSAPatch/issues/33" target="_blank" rel="noopener noreferrer">⛔</a></td>
+    <td>✅</td>
   </tr>
 </tbody>
 </table>


### PR DESCRIPTION
WSA `v2305.40000.3.0` works smoothly with windows 10, unlike `v2304`, have done all the testing (in x64 pc) so that you don't have to. https://github.com/cinit/WSAPatch/issues/33 😉 