### PR TITLE
Fix Windows 10 installation Appx commands error when pwsh.exe installed

### DIFF
--- a/MagiskOnWSA/installer/Install.ps1
+++ b/MagiskOnWSA/installer/Install.ps1
@@ -57,7 +57,7 @@ Function Finish {
     Start-Process "wsa://com.android.vending"
 }
 
-If (Check-Windows11 -And Test-CommandExist pwsh.exe) {
+If ((Check-Windows11) -And (Test-CommandExist 'pwsh.exe')) {
     $pwsh = "pwsh.exe"
 } Else {
     $pwsh = "powershell.exe"

--- a/MagiskOnWSA/installer/Install.ps1
+++ b/MagiskOnWSA/installer/Install.ps1
@@ -38,6 +38,10 @@ function Get-InstalledDependencyVersion {
     }
 }
 
+Function Check-Windows11 {
+    RETURN (Get-ComputerInfo | Select-Object -expand OsName) -match 11
+}
+
 Function Test-CommandExist {
     Param ($Command)
     $OldPreference = $ErrorActionPreference
@@ -53,10 +57,9 @@ Function Finish {
     Start-Process "wsa://com.android.vending"
 }
 
-If (Test-CommandExist pwsh.exe) {
+If (Check-Windows11 -And Test-CommandExist pwsh.exe) {
     $pwsh = "pwsh.exe"
-}
-Else {
+} Else {
     $pwsh = "powershell.exe"
 }
 


### PR DESCRIPTION
Issue PowerShell/PowerShell#19031 still exists on Windows 10 and not be fixed.

![image](https://github.com/MustardChef/WSABuilds/assets/36123961/a7a67d28-0ce4-494a-9291-2ee7aa5f72dc)
