### PR TITLE
Add Trickcal Global to app compatibility list

### DIFF
--- a/Documentation/WSABuilds/App Compatibility.md
+++ b/Documentation/WSABuilds/App Compatibility.md
@@ -615,6 +615,7 @@ wsa://com.apple.android.music
 | The King Of Fighters Allstar | 1.9.3 | 11 | ✅ | Blank screen/app crash on first boot, works on second boot upwards
 | This War of Mine | 1.0 | 11 | ❌ | Infinite loop at start-up screen
 | Traffic Racer | 3.5 | 13, 12, 11 | ✅ || Keyboard supported
+| Trickcal: Chibi Go | 1.0.3 | 13 | ✅ | Some lag at the start with 1% lows, runs better after a while with Subsystem resources set to Continuous and Vulkan driver set to D3D12, possibly better with more memory allocated | Tested with a laptop RTX2050. Did not test with any login and instead used a guest account.
 | Toca Kitchen 2 | 2.2-play | 13 | ⚠️ | You can't access the game settings (or any swipe action) with a keyboard and mouse even with trackpad gestures | Recommended to use a touchscreen but it is also possible to play the game with just only the mouse.
 | True Skate | 1.5.39 | 11 | ✅ | Minor graphical glitches
 | Uma Musume: Pretty Derby (ウマ娘 プリティーダービー; JP) | 1.16.0 | 11 | ⚠️ | Doesn't work with Nvidia GeForce GTX 1660. Works with Microsoft Basic Render Driver with graphical issues. | Some features may require GMS.


### PR DESCRIPTION
I tested Trickcal: Chibi Go since I had it installed to test PvZ 2 Reflourished for a friend. (The mod did run well if you were going to ask)
It was quite laggy at the start and graphically looked worse than on my phone.
But after changing the graphical settings ingame and some WSA settings, it ran much better.
1% lows still prop up but got better after a while.
I did not however check with any logins and just used a newly created guest account so I'm unsure if this is a potential ban offense or if you are even able to login.