### PR TITLE
Shorten the `label`

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,4 +1,4 @@
-name: Documentation 
+name: Documentation
 description: Report an issue with or request something regarding the project's documentation.
 title: "[DOC]"
 labels: documentation
@@ -6,6 +6,8 @@ body:
   - type: textarea
     id: description
     attributes:
-      label: Please provide a clear and concise description of the changes you would like to see made to the documentation.
+      label: Desired change
+      description: Please provide a clear and concise description of the changes you would like to see made to the documentation.
+      placeholder: […info…] in […documentation link…] needs to be [added / deleted / modefied to … / updated to …] due to […reason…].
     validations:
       required: true


### PR DESCRIPTION
1. Shorten the `label` to keep issues concise.
2. Move the former long `label` to the `description` field.
3. Give an example format in the `placeholder` field.
4. Remove extra spaces.