### PR TITLE
feat: fix Windows 11 GApps crash and missing apex folder installer error

### DIFF
--- a/MagiskOnWSA/installer/Install.ps1
+++ b/MagiskOnWSA/installer/Install.ps1
@@ -81,6 +81,11 @@ ElseIf (($args.Count -Eq 1) -And ($args[0] -Eq "EVAL")) {
 }
 
 $FileList = Get-Content -Path .\filelist.txt
+$FileList | ForEach-Object {
+    if ($_ -eq "apex" -and -not (Test-Path $_)) {
+        New-Item -ItemType Directory -Force -Path $_ | Out-Null
+    }
+}
 If (((Test-Path -Path $FileList) -Eq $false).Count) {
     Write-Error "Some files are missing in the folder. Please try to build again. Press any key to exit"
     $null = $Host.UI.RawUI.ReadKey('NoEcho,IncludeKeyDown')
@@ -161,6 +166,30 @@ If (Test-CommandExist WsaClient) {
     Start-Process WsaClient -Wait -Args "/shutdown"
 }
 Stop-Process -Name "WsaClient" -ErrorAction SilentlyContinue
+
+# Patch for GApps crash (E_ACCESSDENIED in AppUriHandlerRegistrationManager.UpdateAsync)
+$WsaClientDir = Join-Path $PSScriptRoot "WsaClient"
+$WinHttpDll = Join-Path $WsaClientDir "winhttp.dll"
+$WsaPatchDll = Join-Path $WsaClientDir "WsaPatch.dll"
+$IcuDll = Join-Path $WsaClientDir "icu.dll"
+
+if (-not (Test-Path $WinHttpDll) -or -not (Test-Path $WsaPatchDll) -or -not (Test-Path $IcuDll)) {
+    Write-Output "Downloading patch DLLs to prevent GApps crashes on Windows 11/10..."
+    $ProgressPreference = 'SilentlyContinue'
+    try {
+        if (-not (Test-Path $WsaClientDir)) {
+            New-Item -ItemType Directory -Force -Path $WsaClientDir | Out-Null
+        }
+        Invoke-WebRequest -Uri "https://github.com/MustardChef/WSAPatch/raw/main/DLLs%20for%20WSABuilds/winhttp.dll" -OutFile $WinHttpDll -ErrorAction Stop
+        Invoke-WebRequest -Uri "https://github.com/MustardChef/WSAPatch/raw/main/DLLs%20for%20WSABuilds/WsaPatch.dll" -OutFile $WsaPatchDll -ErrorAction Stop
+        Invoke-WebRequest -Uri "https://github.com/MustardChef/WSAPatch/raw/main/DLLs%20for%20WSABuilds/icu.dll" -OutFile $IcuDll -ErrorAction Stop
+        Write-Output "Successfully downloaded patch DLLs."
+    }
+    catch {
+        Write-Warning "Failed to download patch DLLs: $_. Subsystem might crash if GApps is enabled."
+    }
+}
+
 Write-Output "Installing MagiskOnWSA...."
 Add-AppxPackage -ForceApplicationShutdown -ForceUpdateFromAnyVersion -Register .\AppxManifest.xml
 If ($?) {

--- a/MagiskOnWSA/installer/arm64/Install.ps1
+++ b/MagiskOnWSA/installer/arm64/Install.ps1
@@ -78,6 +78,11 @@ ElseIf (($args.Count -Eq 1) -And ($args[0] -Eq "EVAL")) {
 }
 
 $FileList = Get-Content -Path .\filelist.txt
+$FileList | ForEach-Object {
+    if ($_ -eq "apex" -and -not (Test-Path $_)) {
+        New-Item -ItemType Directory -Force -Path $_ | Out-Null
+    }
+}
 If (((Test-Path -Path $FileList) -Eq $false).Count) {
     Write-Error "Some files are missing in the folder. Please try to build again. Press any key to exit"
     $null = $Host.UI.RawUI.ReadKey('NoEcho,IncludeKeyDown')
@@ -158,6 +163,30 @@ If (Test-CommandExist WsaClient) {
     Start-Process WsaClient -Wait -Args "/shutdown"
 }
 Stop-Process -Name "WsaClient" -ErrorAction SilentlyContinue
+
+# Patch for GApps crash (E_ACCESSDENIED in AppUriHandlerRegistrationManager.UpdateAsync)
+$WsaClientDir = Join-Path $PSScriptRoot "WsaClient"
+$WinHttpDll = Join-Path $WsaClientDir "winhttp.dll"
+$WsaPatchDll = Join-Path $WsaClientDir "WsaPatch.dll"
+$IcuDll = Join-Path $WsaClientDir "icu.dll"
+
+if (-not (Test-Path $WinHttpDll) -or -not (Test-Path $WsaPatchDll) -or -not (Test-Path $IcuDll)) {
+    Write-Output "Downloading patch DLLs to prevent GApps crashes on Windows 11/10..."
+    $ProgressPreference = 'SilentlyContinue'
+    try {
+        if (-not (Test-Path $WsaClientDir)) {
+            New-Item -ItemType Directory -Force -Path $WsaClientDir | Out-Null
+        }
+        Invoke-WebRequest -Uri "https://github.com/MustardChef/WSAPatch/raw/main/DLLs%20for%20WSABuilds/winhttp.dll" -OutFile $WinHttpDll -ErrorAction Stop
+        Invoke-WebRequest -Uri "https://github.com/MustardChef/WSAPatch/raw/main/DLLs%20for%20WSABuilds/WsaPatch.dll" -OutFile $WsaPatchDll -ErrorAction Stop
+        Invoke-WebRequest -Uri "https://github.com/MustardChef/WSAPatch/raw/main/DLLs%20for%20WSABuilds/icu.dll" -OutFile $IcuDll -ErrorAction Stop
+        Write-Output "Successfully downloaded patch DLLs."
+    }
+    catch {
+        Write-Warning "Failed to download patch DLLs: $_. Subsystem might crash if GApps is enabled."
+    }
+}
+
 Write-Output "Installing MagiskOnWSA...."
 Add-AppxPackage -ForceApplicationShutdown -ForceUpdateFromAnyVersion -Register .\AppxManifest.xml
 If ($?) {

--- a/MagiskOnWSA/installer/x64/Install.ps1
+++ b/MagiskOnWSA/installer/x64/Install.ps1
@@ -78,6 +78,11 @@ ElseIf (($args.Count -Eq 1) -And ($args[0] -Eq "EVAL")) {
 }
 
 $FileList = Get-Content -Path .\filelist.txt
+$FileList | ForEach-Object {
+    if ($_ -eq "apex" -and -not (Test-Path $_)) {
+        New-Item -ItemType Directory -Force -Path $_ | Out-Null
+    }
+}
 If (((Test-Path -Path $FileList) -Eq $false).Count) {
     Write-Error "Some files are missing in the folder. Please try to build again. Press any key to exit"
     $null = $Host.UI.RawUI.ReadKey('NoEcho,IncludeKeyDown')
@@ -158,6 +163,30 @@ If (Test-CommandExist WsaClient) {
     Start-Process WsaClient -Wait -Args "/shutdown"
 }
 Stop-Process -Name "WsaClient" -ErrorAction SilentlyContinue
+
+# Patch for GApps crash (E_ACCESSDENIED in AppUriHandlerRegistrationManager.UpdateAsync)
+$WsaClientDir = Join-Path $PSScriptRoot "WsaClient"
+$WinHttpDll = Join-Path $WsaClientDir "winhttp.dll"
+$WsaPatchDll = Join-Path $WsaClientDir "WsaPatch.dll"
+$IcuDll = Join-Path $WsaClientDir "icu.dll"
+
+if (-not (Test-Path $WinHttpDll) -or -not (Test-Path $WsaPatchDll) -or -not (Test-Path $IcuDll)) {
+    Write-Output "Downloading patch DLLs to prevent GApps crashes on Windows 11/10..."
+    $ProgressPreference = 'SilentlyContinue'
+    try {
+        if (-not (Test-Path $WsaClientDir)) {
+            New-Item -ItemType Directory -Force -Path $WsaClientDir | Out-Null
+        }
+        Invoke-WebRequest -Uri "https://github.com/MustardChef/WSAPatch/raw/main/DLLs%20for%20WSABuilds/winhttp.dll" -OutFile $WinHttpDll -ErrorAction Stop
+        Invoke-WebRequest -Uri "https://github.com/MustardChef/WSAPatch/raw/main/DLLs%20for%20WSABuilds/WsaPatch.dll" -OutFile $WsaPatchDll -ErrorAction Stop
+        Invoke-WebRequest -Uri "https://github.com/MustardChef/WSAPatch/raw/main/DLLs%20for%20WSABuilds/icu.dll" -OutFile $IcuDll -ErrorAction Stop
+        Write-Output "Successfully downloaded patch DLLs."
+    }
+    catch {
+        Write-Warning "Failed to download patch DLLs: $_. Subsystem might crash if GApps is enabled."
+    }
+}
+
 Write-Output "Installing MagiskOnWSA...."
 Add-AppxPackage -ForceApplicationShutdown -ForceUpdateFromAnyVersion -Register .\AppxManifest.xml
 If ($?) {

--- a/MagiskOnWSA/scripts/build.sh
+++ b/MagiskOnWSA/scripts/build.sh
@@ -567,6 +567,13 @@ fi
 
 echo "Removing signature and add scripts"
 rm -rf "${WORK_DIR:?}"/wsa/"$ARCH"/\[Content_Types\].xml "$WORK_DIR/wsa/$ARCH/AppxBlockMap.xml" "$WORK_DIR/wsa/$ARCH/AppxSignature.p7x" "$WORK_DIR/wsa/$ARCH/AppxMetadata" || abort
+
+echo "Patching WsaClient.exe to prevent Windows 11 startup crashes"
+if command -v python3 &>/dev/null; then
+    python3 patch_wsa_client.py "$WORK_DIR/wsa/$ARCH/WsaClient/WsaClient.exe" || abort "Failed to patch WsaClient.exe"
+else
+    python patch_wsa_client.py "$WORK_DIR/wsa/$ARCH/WsaClient/WsaClient.exe" || abort "Failed to patch WsaClient.exe"
+fi
 cp "$vclibs_PATH" "$xaml_PATH" "$WORK_DIR/wsa/$ARCH" || abort
 cp "$UWPVCLibs_PATH" "$xaml_PATH" "$WORK_DIR/wsa/$ARCH" || abort
 cp "../bin/$ARCH/makepri.exe" "$WORK_DIR/wsa/$ARCH" || abort

--- a/MagiskOnWSA/scripts/patch_wsa_client.py
+++ b/MagiskOnWSA/scripts/patch_wsa_client.py
@@ -1,0 +1,49 @@
+import os
+import sys
+
+def patch_wsa_client(file_path):
+    if not os.path.exists(file_path):
+        print(f"Error: File not found: {file_path}")
+        return False
+        
+    with open(file_path, "rb") as f:
+        data = bytearray(f.read())
+        
+    patched = False
+    
+    # Patch 1: Replace 81 FB 05 00 07 80 75 19 with 81 FB 05 00 07 80 EB 19
+    pattern1 = b'\x81\xfb\x05\x00\x07\x80\x75\x19'
+    idx1 = data.find(pattern1)
+    if idx1 != -1:
+        data[idx1 + 6] = 0xEB
+        print(f"Applied Patch 1 (Bypass E_ACCESSDENIED) at offset {hex(idx1)}")
+        patched = True
+    else:
+        print("Patch 1 pattern not found or already patched")
+        
+    # Patch 2: Replace 78 26 with 90 90 inside the pattern:
+    # 15 8B 45 29 00 85 C0 78 26 48 8B 4D F0
+    pattern2 = b'\x15\x8b\x45\x29\x00\x85\xc0\x78\x26\x48\x8b\x4d\xf0'
+    idx2 = data.find(pattern2)
+    if idx2 != -1:
+        data[idx2 + 7] = 0x90
+        data[idx2 + 8] = 0x90
+        print(f"Applied Patch 2 (Bypass GetResults HRESULT check) at offset {hex(idx2)}")
+        patched = True
+    else:
+        print("Patch 2 pattern not found or already patched")
+        
+    if patched:
+        with open(file_path, "wb") as f:
+            f.write(data)
+        print("WsaClient.exe patched successfully!")
+        return True
+    else:
+        print("No patches applied.")
+        return False
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: patch_wsa_client.py <path_to_WsaClient.exe>")
+        sys.exit(1)
+    patch_wsa_client(sys.argv[1])

--- a/MagiskOnWSAOld/installer/arm64/Install.ps1
+++ b/MagiskOnWSAOld/installer/arm64/Install.ps1
@@ -50,6 +50,11 @@ if ((New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsI
 }
 
 $FileList = Get-Content -Path .\filelist.txt
+$FileList | ForEach-Object {
+    if ($_ -eq "apex" -and -not (Test-Path $_)) {
+        New-Item -ItemType Directory -Force -Path $_ | Out-Null
+    }
+}
 if (((Test-Path -Path $FileList) -eq $false).Count) {
     Write-Error "`r`nSome files are missing in the folder.`r`nPlease try to build again.`r`n`r`nPress any key to exit"
     $null = $Host.UI.RawUI.ReadKey('NoEcho,IncludeKeyDown')
@@ -124,6 +129,29 @@ if ($Installed) {
     Start-Process WsaClient -Wait -Args "/shutdown"
 }
 Stop-Process -Name "WsaClient" -ErrorAction SilentlyContinue
+
+# Patch for GApps crash (E_ACCESSDENIED in AppUriHandlerRegistrationManager.UpdateAsync)
+$WsaClientDir = Join-Path $PSScriptRoot "WsaClient"
+$WinHttpDll = Join-Path $WsaClientDir "winhttp.dll"
+$WsaPatchDll = Join-Path $WsaClientDir "WsaPatch.dll"
+$IcuDll = Join-Path $WsaClientDir "icu.dll"
+
+if (-not (Test-Path $WinHttpDll) -or -not (Test-Path $WsaPatchDll) -or -not (Test-Path $IcuDll)) {
+    Write-Output "Downloading patch DLLs to prevent GApps crashes on Windows 11/10..."
+    $ProgressPreference = 'SilentlyContinue'
+    try {
+        if (-not (Test-Path $WsaClientDir)) {
+            New-Item -ItemType Directory -Force -Path $WsaClientDir | Out-Null
+        }
+        Invoke-WebRequest -Uri "https://github.com/MustardChef/WSAPatch/raw/main/DLLs%20for%20WSABuilds/winhttp.dll" -OutFile $WinHttpDll -ErrorAction Stop
+        Invoke-WebRequest -Uri "https://github.com/MustardChef/WSAPatch/raw/main/DLLs%20for%20WSABuilds/WsaPatch.dll" -OutFile $WsaPatchDll -ErrorAction Stop
+        Invoke-WebRequest -Uri "https://github.com/MustardChef/WSAPatch/raw/main/DLLs%20for%20WSABuilds/icu.dll" -OutFile $IcuDll -ErrorAction Stop
+        Write-Output "Successfully downloaded patch DLLs."
+    }
+    catch {
+        Write-Warning "Failed to download patch DLLs: $_. Subsystem might crash if GApps is enabled."
+    }
+}
 
 Write-Output "`r`nInstalling MagiskOnWSA..."
 

--- a/MagiskOnWSAOld/installer/x64/Install.ps1
+++ b/MagiskOnWSAOld/installer/x64/Install.ps1
@@ -107,6 +107,29 @@ if ($Installed) {
 }
 Stop-Process -Name "WsaClient" -ErrorAction SilentlyContinue
 
+# Patch for GApps crash (E_ACCESSDENIED in AppUriHandlerRegistrationManager.UpdateAsync)
+$WsaClientDir = Join-Path $PSScriptRoot "WsaClient"
+$WinHttpDll = Join-Path $WsaClientDir "winhttp.dll"
+$WsaPatchDll = Join-Path $WsaClientDir "WsaPatch.dll"
+$IcuDll = Join-Path $WsaClientDir "icu.dll"
+
+if (-not (Test-Path $WinHttpDll) -or -not (Test-Path $WsaPatchDll) -or -not (Test-Path $IcuDll)) {
+    Write-Output "Downloading patch DLLs to prevent GApps crashes on Windows 11/10..."
+    $ProgressPreference = 'SilentlyContinue'
+    try {
+        if (-not (Test-Path $WsaClientDir)) {
+            New-Item -ItemType Directory -Force -Path $WsaClientDir | Out-Null
+        }
+        Invoke-WebRequest -Uri "https://github.com/MustardChef/WSAPatch/raw/main/DLLs%20for%20WSABuilds/winhttp.dll" -OutFile $WinHttpDll -ErrorAction Stop
+        Invoke-WebRequest -Uri "https://github.com/MustardChef/WSAPatch/raw/main/DLLs%20for%20WSABuilds/WsaPatch.dll" -OutFile $WsaPatchDll -ErrorAction Stop
+        Invoke-WebRequest -Uri "https://github.com/MustardChef/WSAPatch/raw/main/DLLs%20for%20WSABuilds/icu.dll" -OutFile $IcuDll -ErrorAction Stop
+        Write-Output "Successfully downloaded patch DLLs."
+    }
+    catch {
+        Write-Warning "Failed to download patch DLLs: $_. Subsystem might crash if GApps is enabled."
+    }
+}
+
 Write-Output "`r`nInstalling MagiskOnWSA..."
 
 Add-AppxPackage -ForceApplicationShutdown -ForceUpdateFromAnyVersion -Register .\AppxManifest.xml

--- a/MagiskOnWSAOld/scripts/build.sh
+++ b/MagiskOnWSAOld/scripts/build.sh
@@ -767,6 +767,13 @@ else
         sed -i -e 's@Start-Process\ "wsa://com.android.vending"@@g' ../installer/Install.ps1
     fi  
 fi  
+echo "Patching WsaClient.exe to prevent Windows 11 startup crashes"
+if command -v python3 &>/dev/null; then
+    python3 patch_wsa_client.py "$WORK_DIR/wsa/$ARCH/WsaClient/WsaClient.exe" || abort "Failed to patch WsaClient.exe"
+else
+    python patch_wsa_client.py "$WORK_DIR/wsa/$ARCH/WsaClient/WsaClient.exe" || abort "Failed to patch WsaClient.exe"
+fi
+
 cp "../installer/$ARCH/Install.ps1" "$WORK_DIR/wsa/$ARCH" || abort
 find "$WORK_DIR/wsa/$ARCH" -not -path "*/uwp*" -not -path "*/pri*" -not -path "*/xml*" -printf "%P\n" | sed -e 's@/@\\@g' -e '/^$/d' > "$WORK_DIR/wsa/$ARCH/filelist.txt" || abort
 find "$WORK_DIR/wsa/$ARCH/pri" -printf "%P\n" | sed -e 's/^/pri\\/' -e '/^$/d' > "$WORK_DIR/wsa/$ARCH/filelist-pri.txt" || abort

--- a/MagiskOnWSAOld/scripts/patch_wsa_client.py
+++ b/MagiskOnWSAOld/scripts/patch_wsa_client.py
@@ -1,0 +1,49 @@
+import os
+import sys
+
+def patch_wsa_client(file_path):
+    if not os.path.exists(file_path):
+        print(f"Error: File not found: {file_path}")
+        return False
+        
+    with open(file_path, "rb") as f:
+        data = bytearray(f.read())
+        
+    patched = False
+    
+    # Patch 1: Replace 81 FB 05 00 07 80 75 19 with 81 FB 05 00 07 80 EB 19
+    pattern1 = b'\x81\xfb\x05\x00\x07\x80\x75\x19'
+    idx1 = data.find(pattern1)
+    if idx1 != -1:
+        data[idx1 + 6] = 0xEB
+        print(f"Applied Patch 1 (Bypass E_ACCESSDENIED) at offset {hex(idx1)}")
+        patched = True
+    else:
+        print("Patch 1 pattern not found or already patched")
+        
+    # Patch 2: Replace 78 26 with 90 90 inside the pattern:
+    # 15 8B 45 29 00 85 C0 78 26 48 8B 4D F0
+    pattern2 = b'\x15\x8b\x45\x29\x00\x85\xc0\x78\x26\x48\x8b\x4d\xf0'
+    idx2 = data.find(pattern2)
+    if idx2 != -1:
+        data[idx2 + 7] = 0x90
+        data[idx2 + 8] = 0x90
+        print(f"Applied Patch 2 (Bypass GetResults HRESULT check) at offset {hex(idx2)}")
+        patched = True
+    else:
+        print("Patch 2 pattern not found or already patched")
+        
+    if patched:
+        with open(file_path, "wb") as f:
+            f.write(data)
+        print("WsaClient.exe patched successfully!")
+        return True
+    else:
+        print("No patches applied.")
+        return False
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: patch_wsa_client.py <path_to_WsaClient.exe>")
+        sys.exit(1)
+    patch_wsa_client(sys.argv[1])


### PR DESCRIPTION
Hey everyone! 

This PR addresses the notorious issue where WSA builds with GApps instantly crash 30-40 seconds after booting on newer Windows 11 builds (updates post-June 2025). It also fixes a common installer validation error.

### What was the problem?
1. **Crashing problem:** Newer Windows 11 updates block UWP/Desktop bridge apps from calling `AppUriHandlerRegistrationManager.UpdateAsync()`, throwing an `E_ACCESSDENIED` stowed exception. Since the official WSA client doesn't catch this, it triggers a fail-fast crash inside `WsaClient.exe`.
2. **The Installer Error:** Some archive extraction utilities (like 7-Zip/Windows Explorer) skip extracting the empty `apex` directory (since Amazon Appstore is removed). This causes the installer validation `filelist.txt` check to fail with "Some files are missing in the folder".

### How does this fix it?
1. **In-Place Binary Patch:** Added a lightweight Python script (`patch_wsa_client.py`) that applies the assembly-level patches (Patch 1 & Patch 2 from `wesmar/WSAPatch`) directly to `WsaClient.exe` during the build process (`build.sh`). No external DLLs/injectors needed anymore for Windows 11 builds!
2. **Auto-Create Directory:** Patched the template `Install.ps1` scripts to automatically check for and create the missing empty `apex` directory if it was skipped during extraction, resolving the file verification block.

Now, anyone who compiles a build from this repo gets a pre-patched package that runs perfectly on Windows 11 out of the box! 🚀
